### PR TITLE
Add `--atomic` option for helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,26 +8,26 @@ GitHub action for deploying to AWS EKS clusters using helm.
 
 Following inputs can be used as `step.with` keys
 
-| Name                      | Type   | Description                                                                      |
-|---------------------------|--------|----------------------------------------------------------------------------------|
-| `atomic`                  | String | Roll the install/upgrade back in the face of failure.                            |
-| `aws-secret-access-key`   | String | AWS secret access key part of the aws credentials. This is used to login to EKS. |
-| `aws-access-key-id`       | String | AWS access key id part of the aws credentials. This is used to login to EKS.     |
-| `aws-region`              | String | AWS region to use. This must match the region your desired cluster lies in.      |
-| `cluster-name`            | String | The name of the desired cluster.                                                 |
-| `cluster-role-arn`        | String | If you wish to assume an admin role, provide the role arn here to login as.      |
-| `config-files`            | String | Comma separated list of helm values files.                                       |
-| `namespace`               | String | Kubernetes namespace to use.                                                     |
-| `values`                  | String | Comma separates list of value set for helms. e.x: key1=value1,key2=value2        |
-| `name`                    | String | The name of the helm release                                                     |
-| `chart-path`              | String | The path to the chart. (For local helm chart)                                    |
-| `chart-repository`        | String | The URL of the chart repository. (For remote repo)                               |
-| `chart-name`              | String | Helm chart name inside the repository. (For remote repo)                         |
-| `repo-username`           | String | Username for repository basic auth                                               |
-| `repo-password`           | String | Password for repository basic auth                                               |
-| `chart-version`           | String | The version number of the chart                                                  |
-| `helm-ecr-aws-account-id` | String | AWS account ID for the helm ECR                                                  |
-| `helm-ecr-aws-region`     | String | AWS region for the helm ECR                                                      |
+| Name                      | Type    | Description                                                                      |
+|---------------------------|---------|----------------------------------------------------------------------------------|
+| `atomic`                  | Boolean | Roll the install/upgrade back in the face of failure.                            |
+| `aws-secret-access-key`   | String  | AWS secret access key part of the aws credentials. This is used to login to EKS. |
+| `aws-access-key-id`       | String  | AWS access key id part of the aws credentials. This is used to login to EKS.     |
+| `aws-region`              | String  | AWS region to use. This must match the region your desired cluster lies in.      |
+| `cluster-name`            | String  | The name of the desired cluster.                                                 |
+| `cluster-role-arn`        | String  | If you wish to assume an admin role, provide the role arn here to login as.      |
+| `config-files`            | String  | Comma separated list of helm values files.                                       |
+| `namespace`               | String  | Kubernetes namespace to use.                                                     |
+| `values`                  | String  | Comma separates list of value set for helms. e.x: key1=value1,key2=value2        |
+| `name`                    | String  | The name of the helm release                                                     |
+| `chart-path`              | String  | The path to the chart. (For local helm chart)                                    |
+| `chart-repository`        | String  | The URL of the chart repository. (For remote repo)                               |
+| `chart-name`              | String  | Helm chart name inside the repository. (For remote repo)                         |
+| `repo-username`           | String  | Username for repository basic auth                                               |
+| `repo-password`           | String  | Password for repository basic auth                                               |
+| `chart-version`           | String  | The version number of the chart                                                  |
+| `helm-ecr-aws-account-id` | String  | AWS account ID for the helm ECR                                                  |
+| `helm-ecr-aws-region`     | String  | AWS region for the helm ECR                                                      |
 
 
 ## Example usage

--- a/README.md
+++ b/README.md
@@ -10,24 +10,24 @@ Following inputs can be used as `step.with` keys
 
 | Name                      | Type    | Description                                                                      |
 |---------------------------|---------|----------------------------------------------------------------------------------|
-| `atomic`                  | Boolean | Roll the install/upgrade back in the face of failure.                            |
-| `aws-secret-access-key`   | String  | AWS secret access key part of the aws credentials. This is used to login to EKS. |
-| `aws-access-key-id`       | String  | AWS access key id part of the aws credentials. This is used to login to EKS.     |
-| `aws-region`              | String  | AWS region to use. This must match the region your desired cluster lies in.      |
-| `cluster-name`            | String  | The name of the desired cluster.                                                 |
-| `cluster-role-arn`        | String  | If you wish to assume an admin role, provide the role arn here to login as.      |
-| `config-files`            | String  | Comma separated list of helm values files.                                       |
-| `namespace`               | String  | Kubernetes namespace to use.                                                     |
-| `values`                  | String  | Comma separates list of value set for helms. e.x: key1=value1,key2=value2        |
-| `name`                    | String  | The name of the helm release                                                     |
-| `chart-path`              | String  | The path to the chart. (For local helm chart)                                    |
-| `chart-repository`        | String  | The URL of the chart repository. (For remote repo)                               |
-| `chart-name`              | String  | Helm chart name inside the repository. (For remote repo)                         |
-| `repo-username`           | String  | Username for repository basic auth                                               |
-| `repo-password`           | String  | Password for repository basic auth                                               |
-| `chart-version`           | String  | The version number of the chart                                                  |
-| `helm-ecr-aws-account-id` | String  | AWS account ID for the helm ECR                                                  |
-| `helm-ecr-aws-region`     | String  | AWS region for the helm ECR                                                      |
+| `atomic`                  | String | Roll the install/upgrade back in the face of failure.                            |
+| `aws-secret-access-key`   | String | AWS secret access key part of the aws credentials. This is used to login to EKS. |
+| `aws-access-key-id`       | String | AWS access key id part of the aws credentials. This is used to login to EKS.     |
+| `aws-region`              | String | AWS region to use. This must match the region your desired cluster lies in.      |
+| `cluster-name`            | String | The name of the desired cluster.                                                 |
+| `cluster-role-arn`        | String | If you wish to assume an admin role, provide the role arn here to login as.      |
+| `config-files`            | String | Comma separated list of helm values files.                                       |
+| `namespace`               | String | Kubernetes namespace to use.                                                     |
+| `values`                  | String | Comma separates list of value set for helms. e.x: key1=value1,key2=value2        |
+| `name`                    | String | The name of the helm release                                                     |
+| `chart-path`              | String | The path to the chart. (For local helm chart)                                    |
+| `chart-repository`        | String | The URL of the chart repository. (For remote repo)                               |
+| `chart-name`              | String | Helm chart name inside the repository. (For remote repo)                         |
+| `repo-username`           | String | Username for repository basic auth                                               |
+| `repo-password`           | String | Password for repository basic auth                                               |
+| `chart-version`           | String | The version number of the chart                                                  |
+| `helm-ecr-aws-account-id` | String | AWS account ID for the helm ECR                                                  |
+| `helm-ecr-aws-region`     | String | AWS region for the helm ECR                                                      |
 
 
 ## Example usage

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Following inputs can be used as `step.with` keys
 
 | Name                      | Type   | Description                                                                      |
 |---------------------------|--------|----------------------------------------------------------------------------------|
+| `atomic`                  | String | Roll the install/upgrade back in the face of failure.                            |
 | `aws-secret-access-key`   | String | AWS secret access key part of the aws credentials. This is used to login to EKS. |
 | `aws-access-key-id`       | String | AWS access key id part of the aws credentials. This is used to login to EKS.     |
 | `aws-region`              | String | AWS region to use. This must match the region your desired cluster lies in.      |

--- a/README.md
+++ b/README.md
@@ -10,24 +10,24 @@ Following inputs can be used as `step.with` keys
 
 | Name                      | Type    | Description                                                                      |
 |---------------------------|---------|----------------------------------------------------------------------------------|
-| `atomic`                  | String | Roll the install/upgrade back in the face of failure.                            |
-| `aws-secret-access-key`   | String | AWS secret access key part of the aws credentials. This is used to login to EKS. |
-| `aws-access-key-id`       | String | AWS access key id part of the aws credentials. This is used to login to EKS.     |
-| `aws-region`              | String | AWS region to use. This must match the region your desired cluster lies in.      |
-| `cluster-name`            | String | The name of the desired cluster.                                                 |
-| `cluster-role-arn`        | String | If you wish to assume an admin role, provide the role arn here to login as.      |
-| `config-files`            | String | Comma separated list of helm values files.                                       |
-| `namespace`               | String | Kubernetes namespace to use.                                                     |
-| `values`                  | String | Comma separates list of value set for helms. e.x: key1=value1,key2=value2        |
-| `name`                    | String | The name of the helm release                                                     |
-| `chart-path`              | String | The path to the chart. (For local helm chart)                                    |
-| `chart-repository`        | String | The URL of the chart repository. (For remote repo)                               |
-| `chart-name`              | String | Helm chart name inside the repository. (For remote repo)                         |
-| `repo-username`           | String | Username for repository basic auth                                               |
-| `repo-password`           | String | Password for repository basic auth                                               |
-| `chart-version`           | String | The version number of the chart                                                  |
-| `helm-ecr-aws-account-id` | String | AWS account ID for the helm ECR                                                  |
-| `helm-ecr-aws-region`     | String | AWS region for the helm ECR                                                      |
+| `atomic`                  | Boolean | Roll the install/upgrade back in the face of failure.                             |
+| `aws-secret-access-key`   | String  | AWS secret access key part of the aws credentials. This is used to login to EKS.  |
+| `aws-access-key-id`       | String  | AWS access key id part of the aws credentials. This is used to login to EKS.      |
+| `aws-region`              | String  | AWS region to use. This must match the region your desired cluster lies in.       |
+| `cluster-name`            | String  | The name of the desired cluster.                                                  |
+| `cluster-role-arn`        | String  | If you wish to assume an admin role, provide the role arn here to login as.       |
+| `config-files`            | String  | Comma separated list of helm values files.                                        |
+| `namespace`               | String  | Kubernetes namespace to use.                                                      |
+| `values`                  | String  | Comma separates list of value set for helms. e.x: key1=value1,key2=value2         |
+| `name`                    | String  | The name of the helm release                                                      |
+| `chart-path`              | String  | The path to the chart. (For local helm chart)                                     |
+| `chart-repository`        | String  | The URL of the chart repository. (For remote repo)                                |
+| `chart-name`              | String  | Helm chart name inside the repository. (For remote repo)                          |
+| `repo-username`           | String  | Username for repository basic auth                                                |
+| `repo-password`           | String  | Password for repository basic auth                                                |
+| `chart-version`           | String  | The version number of the chart                                                   |
+| `helm-ecr-aws-account-id` | String  | AWS account ID for the helm ECR                                                   |
+| `helm-ecr-aws-region`     | String  | AWS region for the helm ECR                                                       |
 
 
 ## Example usage

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 # action.yml
-name: 'EKS Helm Deployment'
+name: 'Helm Deploy to EKS'
 description: 'Deploy a helm chart to EKS cluster.'
 branding:
     icon: anchor

--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,11 @@ branding:
     icon: anchor
     color: yellow
 inputs:
+    atomic:
+        description: 'Whether helm should roll back in the face of failure'
+        required: false
+        type: boolean
+        default: false
     aws-secret-access-key:
         description: 'AWS credentials used to login to eks.'
         required: false
@@ -74,6 +79,7 @@ runs:
     using: 'docker'
     image: 'Dockerfile'
     env:
+        ATOMIC: ${{ inputs.atomic }}
         AWS_REGION: ${{ inputs.aws-region }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}

--- a/action.yaml
+++ b/action.yaml
@@ -8,8 +8,7 @@ inputs:
     atomic:
         description: 'Whether helm should roll back in the face of failure'
         required: false
-        type: boolean
-        default: false
+        default: "false"
     aws-secret-access-key:
         description: 'AWS credentials used to login to eks.'
         required: false

--- a/deploy.sh
+++ b/deploy.sh
@@ -46,6 +46,10 @@ for config_file in ${DEPLOY_CONFIG_FILES//,/ }; do
   UPGRADE_COMMAND="${UPGRADE_COMMAND} -f ${config_file}"
 done
 
+if [ ${ATOMIC} == "true" ]; then
+  ATOMIC="${UPGRADE_COMMAND} --atomic"
+fi
+
 if [ -n "$DEPLOY_NAMESPACE" ]; then
   UPGRADE_COMMAND="${UPGRADE_COMMAND} -n ${DEPLOY_NAMESPACE}"
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -47,7 +47,7 @@ for config_file in ${DEPLOY_CONFIG_FILES//,/ }; do
 done
 
 if [ ${ATOMIC} == "true" ]; then
-  ATOMIC="${UPGRADE_COMMAND} --atomic"
+  UPGRADE_COMMAND="${UPGRADE_COMMAND} --atomic"
 fi
 
 if [ -n "$DEPLOY_NAMESPACE" ]; then


### PR DESCRIPTION
We want our deploys to rollback when there's a bad pod, etc. Not as a default but we want it as an option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “atomic” input to enable atomic Helm upgrades for safer, all-or-nothing rollouts.
  * Renamed the action to “Helm Deploy to EKS” for clearer identification in workflows and marketplace.

* **Documentation**
  * Updated the README inputs table to include the new atomic flag, with improved alignment and descriptions.
  * Fixed formatting in example usage blocks to ensure proper code fence rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->