### PR TITLE
Add atomic Helm release option

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -46,6 +46,9 @@ inputs:
         description: 'Timeout for the job.'
         required: true
         default: '0'
+    atomic:
+        description: Whether or not to do an atomic release. Setting this to a non-empty value will trigger atomic releases
+        required: false
     update-deps:
         description: 'Update chart dependencies'
         required: false

--- a/deploy.sh
+++ b/deploy.sh
@@ -72,5 +72,9 @@ if [ -n "$CHART_VERSION" ]; then
   UPGRADE_COMMAND="${UPGRADE_COMMAND} --version ${CHART_VERSION}"
 fi
 
+if [ -n "$INPUT_ATOMIC"]
+  UPGRADE_COMMAND="${UPGRADE_COMMAND} --atomic"
+fi
+
 echo "Executing: ${UPGRADE_COMMAND}"
 ${UPGRADE_COMMAND}

--- a/deploy.sh
+++ b/deploy.sh
@@ -72,7 +72,7 @@ if [ -n "$CHART_VERSION" ]; then
   UPGRADE_COMMAND="${UPGRADE_COMMAND} --version ${CHART_VERSION}"
 fi
 
-if [ -n "$INPUT_ATOMIC"]
+if [ -n "$INPUT_ATOMIC"]; then
   UPGRADE_COMMAND="${UPGRADE_COMMAND} --atomic"
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -72,7 +72,7 @@ if [ -n "$CHART_VERSION" ]; then
   UPGRADE_COMMAND="${UPGRADE_COMMAND} --version ${CHART_VERSION}"
 fi
 
-if [ -n "$INPUT_ATOMIC"]; then
+if [ -n "$INPUT_ATOMIC" ]; then
   UPGRADE_COMMAND="${UPGRADE_COMMAND} --atomic"
 fi
 


### PR DESCRIPTION
# 🚀Released Upgrade Notes

## What's Changed
* Added a new input: `atomic`
  * Setting this to a non-empty value will make helm perform an atomic release, meaning that it will rollback failed releases before finishing

# :warning: Warnings

* When using the `atomic` feature, you'll have to set a proper `timeout` value for the Helm release to finish correctly. This is because Helm waits until all related resource are working before marking an atomic release as "Deployed". 

**Full Changelog**: https://github.com/craftech-io/eks-helm-deploy-action/compare/v3.3...feature/atomic-releases